### PR TITLE
Fix buffer overflow in M_LoadDefaults

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -379,7 +379,7 @@ void M_LoadDefaults (void)
 	while (!feof(f))
 	{
 	    isstring = false;
-	    if (fscanf (f, "%79s %[^\n]\n", def, strparm) == 2)
+	    if (fscanf (f, "%79s %99[^\n]\n", def, strparm) == 2)
 	    {
 		if (strparm[0] == '"')
 		{


### PR DESCRIPTION
If `fscanf` doesn't limit the number of characters to be read, it could lead to a buffer overflow which will crash the Nintendo 64. 