### PR TITLE
Restore diminished lighting

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -490,7 +490,7 @@ void R_InitLightTables (void)
         startmap = ((LIGHTLEVELS-1-i)*2)*NUMCOLORMAPS/LIGHTLEVELS;
         for (j=0 ; j<MAXLIGHTZ ; j++)
         {
-            scale = FixedDiv (((SCREENWIDTH)/(2*FRACUNIT)), (j+1)<<LIGHTZSHIFT);
+            scale = FixedDiv ((SCREENWIDTH/2*FRACUNIT), (j+1)<<LIGHTZSHIFT);
             scale >>= LIGHTSCALESHIFT;
             level = startmap - scale/DISTMAP;
 


### PR DESCRIPTION
Restore [light diminishing](https://doomwiki.org/wiki/Light_diminishing). Some extra brackets messed up the light table initialization.