### PR TITLE
Fix aspect ratio and remove black bars

### DIFF
--- a/src/am_map.c
+++ b/src/am_map.c
@@ -126,7 +126,7 @@ extern surface_t *_dc;
 #define MTOF(x) (FixedMul((x),scale_mtof)>>16)
 // translates between frame-buffer and map coordinates
 #define CXMTOF(x)  (f_x + MTOF((x)-m_x))
-#define CYMTOF(y)  ((f_y + (f_h - MTOF((y)-m_y)))+20)
+#define CYMTOF(y)  ((f_y + (f_h - MTOF((y)-m_y))))
 
 // the following is crap
 #define LINE_NEVERSEE ML_DONTDRAW
@@ -899,7 +899,7 @@ void AM_Ticker (void)
 //
 void AM_clearFB(int color)
 {
-    D_memset((uint16_t *)((uintptr_t)_dc->buffer + (20*320*2)), 0, 320*200*2);
+    D_memset((uint16_t *)((uintptr_t)_dc->buffer), 0, SCREENWIDTH*SCREENHEIGHT*2);
 }
 
 
@@ -1052,7 +1052,7 @@ AM_drawMline
 
     if (AM_clipMline(ml, &fl))
     {
-        graphics_draw_line(_dc, fl.a.x, fl.a.y+20, fl.b.x, fl.b.y+20, palarray[color]);
+        graphics_draw_line(_dc, fl.a.x, fl.a.y, fl.b.x, fl.b.y, palarray[color]);
     }
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -858,7 +858,7 @@ void D_DoomMain(void)
     for(int i=0;i<2;i++)
     {
         _dc = lockVideo(1);
-        D_memset(_dc->buffer, 0, 320*240*2);
+        D_memset(_dc->buffer, 0, SCREENWIDTH*SCREENHEIGHT*2);
         unlockVideo(_dc);
     }
 

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -177,7 +177,12 @@ void I_SetPalette(byte* palette)
 
 void I_InitGraphics(void)
 {
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE);
+    display_init( (resolution_t)
+	{
+		.width = SCREENWIDTH,
+		.height = SCREENHEIGHT,
+		.interlaced = false,
+	}, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE );
 }
 
 
@@ -212,6 +217,6 @@ void DebugOutput_String_For_IError(const char *str, int lineNumber, int good)
         {
             strncpy(copied_line, str + ((i-1)*ERROR_LINE_LEN), ERROR_LINE_LEN);
         }
-        graphics_draw_text(_dc, 20, 16+((lineNumber+i)*8), copied_line);
+        graphics_draw_text(_dc, 0, 16+((lineNumber+i)*8), copied_line);
     }
 }

--- a/src/r_draw.c
+++ b/src/r_draw.c
@@ -611,7 +611,7 @@ void R_InitBuffer ( int width, int height )
         viewwindowy = ((SCREENHEIGHT-(SBARHEIGHT)-height) >> 1);
     }
 
-    offset = ytab(viewwindowy+20);
+    offset = ytab(viewwindowy);
 
     for (i=0 ; i<height ; i++)
     {
@@ -737,11 +737,11 @@ static int drew_bg_before=0;
 
 void R_VideoErase ( unsigned ofs, int count )
 {
-    uint16_t* dst = (uint16_t *)((uintptr_t)_dc->buffer + ((ytab(20)+ofs)<<1));
+    uint16_t* dst = (uint16_t *)((uintptr_t)_dc->buffer + ((ofs)<<1));
 
     for (int i=0;i<count;i++)
     {
-        *dst++ = srcp[((((ofs+i)/320)&63)<<6) + (((ofs+i)%320)&63)];
+        *dst++ = srcp[((((ofs+i)/SCREENWIDTH)&63)<<6) + (((ofs+i)%SCREENWIDTH)&63)];
     }
 }
 

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -186,7 +186,7 @@ V_DrawPatch ( int x, int y, int scrn, patch_t* patch )
         uint16_t*    desttop;
         uint16_t*    dest;
 
-        desttop = (uint16_t*)((uintptr_t)_dc->buffer + (uintptr_t)((((y+20)*SCREENWIDTH)+x)*2));
+        desttop = (uint16_t*)((uintptr_t)_dc->buffer + (uintptr_t)((((y)*SCREENWIDTH)+x)*2));
 
         for ( ; col<w ; x++, col++, desttop++)
         { 


### PR DESCRIPTION
Latest trunk libdragon defines a resolution_t struct that can be used to set up and arbitrary resolution mode. This pull request changes I_InitGraphics to get a 320x200 display surface from libdragon, as opposed to 320x240, the same size as what is actually drawn in DOOM. The resolution mode will take care of stretching the image to 4:3 aspect ratio in emulators or on a CRT TV, producing rectangular pixels, just like in DOS. To facilitate this, this pull request also removes all instances of where a hard coded offset of 20 pixels was used to draw to the screen.

![image](https://github.com/jnmartin84/64doom/assets/72971433/f6182f7c-1f1c-4d54-945d-fb9560d9e0d6)

