### PR TITLE
Replace deprecated libdragon functions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ LINK_FLAGS = -G4 -L$(ROOTDIR)/mips64-elf/lib $(LIBS) -Tn64.ld
 PROG_NAME = $(IWAD_PREFIX)
 OPTFLAG = -O3
 
-CFLAGS = -Wno-error=deprecated-declarations -falign-functions=16 -Werror -Wno-error=switch -Wall -g -mabi=o64 -mno-shared -mno-abicalls -mno-branch-likely -mno-llsc -mno-check-zero-division -mfix4300 -std=gnu99 -march=vr4300 -mtune=vr4300 -mips3 -G4 $(OPTFLAG) -I$(ROOTDIR)/mips64-elf/include 
+CFLAGS = -falign-functions=16 -Werror -Wno-error=switch -Wall -g -mabi=o64 -mno-shared -mno-abicalls -mno-branch-likely -mno-llsc -mno-check-zero-division -mfix4300 -std=gnu99 -march=vr4300 -mtune=vr4300 -mips3 -G4 $(OPTFLAG) -I$(ROOTDIR)/mips64-elf/include 
 #-DRANGECHECK
 
 CC = $(GCCN64PREFIX)gcc

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -51,18 +51,14 @@ surface_t *_dc;
 
 surface_t *lockVideo(int wait)
 {
-    surface_t *dc;
-
     if (wait)
     {
-        while (!(dc = display_lock()));
+        return display_get();
     }
     else
     {
-        dc = display_lock();
+        return display_try_get();
     }
-
-    return dc;
 }
 
 void unlockVideo(surface_t *dc)


### PR DESCRIPTION
Since we're using unstable branch now, we can replace display_lock with the new API -> display_get which does the spin lock for us. For the other branch, there is display_try_get which doesn't wait but is allowed to fail and return NULL.

I noticed that so far, lockVideo without waiting is not actually used so perhaps it could be further simplified and just call display_get always but I didn't implement that in this PR.