### PR TITLE
Fix Dangling Pointers

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -838,7 +838,7 @@ void R_SortVisSprites (void)
 //r_things.c:821: error: 'best' may be used uninitialized in this function
 //    vissprite_t*	best;
     vissprite_t*	best = NULL;
-    vissprite_t		unsorted;
+    vissprite_t*   unsorted = (vissprite_t*)malloc(sizeof(vissprite_t)); // Allocate memory for unsorted
     fixed_t		bestscale;
 
     count = vissprite_p - vissprites;
@@ -846,7 +846,8 @@ void R_SortVisSprites (void)
     unsorted.next = unsorted.prev = &unsorted;
 
     if (!count)
-	return;
+        free(unsorted); // Free the allocated memory before returning
+        return;
 
     for (ds=vissprites ; ds<vissprite_p ; ds++)
     {
@@ -880,6 +881,9 @@ void R_SortVisSprites (void)
 	vsprsortedhead.prev->next = best;
 	vsprsortedhead.prev = best;
     }
+	
+	free(unsorted); // Free the allocated memory when no longer needed
+	
 }
 
 


### PR DESCRIPTION
Used chatGPT for the fix so it came up with

The error you're encountering is caused by attempting to store the address of a local variable (`unsorted`) in certain pointer assignments (`(vissprite_p - 1)->next` and `vissprites[0].prev)`, which leads to dangling pointers. To fix this, you can allocate memory for `unsorted` dynamically using `malloc()` and then free it when you no longer need it.

Make sure to include the necessary header file (`stdlib.h`) for the `malloc()` and `free()` functions. Remember to free the allocated memory for unsorted using `free()` when you no longer need it to avoid memory leaks.